### PR TITLE
Removed issue where callback was never called.

### DIFF
--- a/lib/procedure.js
+++ b/lib/procedure.js
@@ -122,9 +122,6 @@ function decideRunCommand(inputPath, outputPath, outputFormat, argString, callba
        * The handler has to be be declared here in order to have acces to the `callback`.
        */
       execHandler = function (err, stdout, stderr) {
-            
-        if (err || stdout || stderr) {
-          
           /*
            * If we've got a callback, use it.
            */
@@ -147,8 +144,7 @@ function decideRunCommand(inputPath, outputPath, outputFormat, argString, callba
             return catchWarningSync(err || null, stdout || null, stderr || null);
             
           }
-        }
-      
+
       };
   
   /*


### PR DESCRIPTION
If pandoc generated no output or warnings, the execHandler was called with `(null, '', '')` which the useless if statement evaluated to falsey. No need for that if statement whatsoever so it was removed.
