### PR TITLE
Throw exception rather than process.exit(1)

### DIFF
--- a/jandoc.js
+++ b/jandoc.js
@@ -238,7 +238,7 @@ module.exports = (function () {
      */
     if (err || !stdout) {
       console.error('ERROR: Could not find Pandoc on your system.\n       Please make sure Haskell and Pandoc are installed before running Jandoc.');
-      process.exit(1);
+      throw new Error('Could not find Pandoc on your system. Please make sure Haskell and Pandoc are installed before running Jandoc');
     }
   });
 


### PR DESCRIPTION
Ugh, even _requiring_ this kills the process? We can throw an exception and use try/catch when requiring jandoc. Let the person requiring choose to kill the process or not.
